### PR TITLE
Workaround for marble pitch issue

### DIFF
--- a/engine/source/sfx/sfxSystem.h
+++ b/engine/source/sfx/sfxSystem.h
@@ -276,6 +276,7 @@ class SFXSystem
 #define SFX_DELETE( source )  \
    if ( source )              \
    {                          \
+      source->setPitch(1.0f); \
       source->deleteObject(); \
       source = NULL;          \
    }                          \


### PR DESCRIPTION
Closes #95

I did a bit more testing, and it seems my hypothesis is correct. When I exited a level while the marble was rolling fast, then the marble rolling pitch went up. When I exited the level with the marble rolling slowly, the marble rolling pitch went down. So, it "remembers" the pitch of the sound when it gets destroyed as the new _baseline_ pitch of the sound.

This is probably due to a bug in the sound library, so probably it should be fixed there instead. But here is a workaround that works for now. Basically, I just set the sound pitch to 1 before destroying the sound, so that it always "remembers" the baseline pitch as the correct pitch.

I added my change to a macro, so this mean that the bug is worked around for all sounds. Though if that is too invasive (and I've only noticed the issue with the marble rolling sound), then I can submit a different patch that _only_ runs that line of code in `Marble::onRemove()` which works just as well.