### PR TITLE
Allow custom usernames from the prefs file

### DIFF
--- a/game/marble/client/defaults.cs
+++ b/game/marble/client/defaults.cs
@@ -8,7 +8,7 @@
 // is not loaded on a client, then the master must be defined. 
 //$pref::Master[0] = "2:v12master.dyndns.org:28002";
 $pref::highScoreName = "Alex";
-$pref::Player::Name = "Alex";
+$pref::Player::Name = XBLiveGetUserName();
 $pref::Player::defaultFov = 90;
 $pref::Player::zoomSpeed = 0;
 $pref::Net::LagThreshold = 400;

--- a/game/marble/client/scripts/xbLive.cs
+++ b/game/marble/client/scripts/xbLive.cs
@@ -1,7 +1,7 @@
 if (isPCBuild())
 {
    // one time setup for these vars
-   $Player::Name = XBLiveGetUserName();
+   $Player::Name = $pref::Player::Name;
    $Player::XBLiveId = XBLiveGetUserId();
 }
 
@@ -446,7 +446,7 @@ function clientUpdatePlayerInfo()
    if (XBLiveIsSignedIn()) // defaults to player on the sign in port
    {
       // update $Player variables
-      $Player::Name = XBLiveGetUserName();
+      $Player::Name = $pref::Player::Name;
       $Player::XBLiveId = XBLiveGetUserId();
       if ($Player::Name $= "" || $Player::XBLiveId $= "")
       {

--- a/game/marble/client/ui/createGameGui.gui
+++ b/game/marble/client/ui/createGameGui.gui
@@ -323,7 +323,7 @@ function CreateGameGui::createGame(%this)
    //$Game::Duration = $pref::Server::TimeLimit * 60;
    //$Server::StayMission = true;        
    $Server::ReturnToLobby = true;
-   $pref::Server::Name = XBLiveGetUserName();
+   $pref::Server::Name = $pref::Player::Name;
    
    //MissionSequence.buildMissionSequence();
    //MissionSequence.setCurrentMission($Server::PostLobbyMissionFile);


### PR DESCRIPTION
Closes #96.

Preface: Honestly, my motivation is that since Microsoft truncates usernames to 5 characters by default, I'm tired of seeing "thear" when playing multiplayer games on my laptop :) If you don't want to merge this, I understand.

---

So, the currently existing workaround for usernames is to read 15 characters of your username and use that as your username. The problem is, I might want to make my username something else, and changing your Windows username is not exactly easy. So, this pull request reworks that to instead, use the property `$pref::Player::Name` that exists in the `prefs.cs` file. That way, if I want to change my username, I can just change it and everything works fine.

Now of course, it would be annoying if everyone had the name "Alex" by default and had to change it. So, when creating the prefs file for the first time, the default name _does_ look at your username to populate the file. That way, someone downloading this for the first time will get the same exact username they already would have.

**The problem**: The lame thing is that currently, `$pref::Player::Name` is set to "Alex" and left like that forever. That means, if someone already has config files created and runs these changes, their name will show up as "Alex" until they manually change it or delete their config files. We could mitigate this by adding in extra code for a release or two that overrides that value with the username every game launch, and then after everyone has updated config files, _then_ we add this change. An idea ¯\_(ツ)_/¯

This isn't a very important commit, just fixes a small annoyance that I have right now. I'm open to suggestions/edits!