### PR TITLE
Make finish pad animation framerate-independant

### DIFF
--- a/engine/source/core/torqueConfig.h
+++ b/engine/source/core/torqueConfig.h
@@ -74,6 +74,9 @@
 // Define me to use MBG physics
 //#define MBG_PHYSICS
 
+// Define me to use a framerate-independant finish pad animation
+#define MBU_FINISH_PAD_FIX
+
 // TEMP: Define me for a temporary fix for moving platform jitter
 #define MBU_TEMP_MP_DESYNC_FIX
 

--- a/engine/source/game/main.cpp
+++ b/engine/source/game/main.cpp
@@ -293,6 +293,11 @@ static U32 gFrameSkip = 0;
 static U32 gFrameCount = 0;
 static bool gGamePaused = false;
 
+#ifdef MBU_FINISH_PAD_FIX
+// TODO: Figure out how to remove this global variable and access dt from Marble::getCameraTransform
+F32 gTimeDelta = 0.0f;
+#endif // MBU_FINISH_PAD_FIX
+
 // Executes an entry script; can be controlled by command-line options.
 bool runEntryScript(int argc, const char** argv)
 {
@@ -730,6 +735,11 @@ void DemoGame::processTimeEvent(TimeEvent* event)
         timeDelta = gTimeAdvance;
     else
         timeDelta = (U32)(elapsedTime * gTimeScale);
+
+#ifdef MBU_FINISH_PAD_FIX
+    // TODO: Figure out how to remove this global variable and access dt from Marble::getCameraTransform
+    gTimeDelta = F32(timeDelta) / 1000.0f;
+#endif // MBU_FINISH_PAD_FIX
 
     Platform::advanceTime(elapsedTime);
     bool tickPass;

--- a/engine/source/game/marble/marble.cpp
+++ b/engine/source/game/marble/marble.cpp
@@ -1541,15 +1541,15 @@ LABEL_7:
 
         Point3F offset = mLastRenderPos - around;
 
-        *pLastRenderVel *= 0.949999988079071f;
+        *pLastRenderVel *= 1 - 0.05f * (60.0f * dt);
 
         Point3F thing2 = forceEffect * 0.2000000029802322f;
 
-        *pLastRenderVel += thing2;
+        *pLastRenderVel += thing2 * (60.0f * dt);
 
         F32 dist = offset.len();
 
-        *pLastRenderVel -= offset * 0.3499999940395355f;
+        *pLastRenderVel -= offset * 0.3499999940395355f * (60.0f * dt);
 
         if (dist > 1.5f)
         {
@@ -1558,7 +1558,7 @@ LABEL_7:
             F32 outforce = mDot(outward, *pLastRenderVel);
             if (outforce > 0.0f)
             {
-                *pLastRenderVel -= unk * outforce * 0.75f;
+                *pLastRenderVel -= unk * outforce * 0.75f * (60.0f * dt);
 
                 Point3F noodles = offset * outforce * 0.5f;
                 noodles = *pLastRenderVel - noodles;
@@ -1572,7 +1572,7 @@ LABEL_7:
                     m_point3F_normalize(noodles);
                 }
 
-                *pLastRenderVel += noodles * outforce * 0.25f;
+                *pLastRenderVel += noodles * outforce * 0.25f * (60.0f * dt);
             }
         }
 
@@ -1612,7 +1612,7 @@ LABEL_7:
             Point3F newAround = normal * 1.5f;
             newAround *= mDot(*pLastRenderVel, normal);
 
-            *pLastRenderVel -= newAround;
+            *pLastRenderVel -= newAround * (60.0f * dt);
 
         } while (i < 4);
 

--- a/engine/source/game/marble/marble.cpp
+++ b/engine/source/game/marble/marble.cpp
@@ -1541,15 +1541,27 @@ LABEL_7:
 
         Point3F offset = mLastRenderPos - around;
 
+#ifdef MBU_FINISH_PAD_FIX
         *pLastRenderVel *= 1 - 0.05f * (60.0f * dt);
+#else
+        *pLastRenderVel *= 0.949999988079071f;
+#endif // MBU_FINISH_PAD_FIX
 
         Point3F thing2 = forceEffect * 0.2000000029802322f;
 
+#ifdef MBU_FINISH_PAD_FIX
         *pLastRenderVel += thing2 * (60.0f * dt);
+#else
+        *pLastRenderVel += thing2;
+#endif // MBU_FINISH_PAD_FIX
 
         F32 dist = offset.len();
 
+#ifdef MBU_FINISH_PAD_FIX
         *pLastRenderVel -= offset * 0.3499999940395355f * (60.0f * dt);
+#else
+        *pLastRenderVel -= offset * 0.3499999940395355f;
+#endif // MBU_FINISH_PAD_FIX
 
         if (dist > 1.5f)
         {
@@ -1558,7 +1570,11 @@ LABEL_7:
             F32 outforce = mDot(outward, *pLastRenderVel);
             if (outforce > 0.0f)
             {
+#ifdef MBU_FINISH_PAD_FIX
                 *pLastRenderVel -= unk * outforce * 0.75f * (60.0f * dt);
+#else
+                *pLastRenderVel -= unk * outforce * 0.75f;
+#endif // MBU_FINISH_PAD_FIX
 
                 Point3F noodles = offset * outforce * 0.5f;
                 noodles = *pLastRenderVel - noodles;
@@ -1572,7 +1588,11 @@ LABEL_7:
                     m_point3F_normalize(noodles);
                 }
 
+#ifdef MBU_FINISH_PAD_FIX
                 *pLastRenderVel += noodles * outforce * 0.25f * (60.0f * dt);
+#else
+                *pLastRenderVel += noodles * outforce * 0.25f;
+#endif // MBU_FINISH_PAD_FIX
             }
         }
 
@@ -1612,7 +1632,11 @@ LABEL_7:
             Point3F newAround = normal * 1.5f;
             newAround *= mDot(*pLastRenderVel, normal);
 
+#ifdef MBU_FINISH_PAD_FIX
             *pLastRenderVel -= newAround * (60.0f * dt);
+#else
+            *pLastRenderVel -= newAround;
+#endif // MBU_FINISH_PAD_FIX
 
         } while (i < 4);
 

--- a/engine/source/game/marble/marblecamera.cpp
+++ b/engine/source/game/marble/marblecamera.cpp
@@ -519,9 +519,17 @@ void Marble::getCameraTransform(F32* pos, MatrixF* mat)
         startCam.z = padMat[10];
 
         position += startCam;
+
+#ifdef MBU_FINISH_PAD_FIX
+        extern F32 gTimeDelta;
+        F32 multOffset = 0.025f * (60.0f * gTimeDelta);
+        position *= multOffset;
+        position += mEffect.lastCamFocus * (1.0f - multOffset);
+#else
         position *= 0.02500000037252903;
 
         position += mEffect.lastCamFocus * 0.9750000238418579;
+#endif // MBU_FINISH_PAD_FIX
     }
 
     F64 verticalOffset = mRadius + 0.25;


### PR DESCRIPTION
Fixes #78. This pull request makes the finish pad animation look the same when running the game at any framerate.

Currently, this only fixes the animation for the position of the marble. The camera still moves too fast, I want to fix that before this pull request gets merged.