### PR TITLE
Use different workaround for sound pitch issue

### DIFF
--- a/engine/source/sfx/dsound/sfxDSVoice.cpp
+++ b/engine/source/sfx/dsound/sfxDSVoice.cpp
@@ -66,6 +66,7 @@ SFXDSVoice::SFXDSVoice( SFXDSBuffer *buffer,
 
 SFXDSVoice::~SFXDSVoice()
 {
+   setPitch(1.0f);
    SAFE_RELEASE( mDSBuffer3D );
    mBuffer->releaseVoice( &mDSBuffer );
 

--- a/engine/source/sfx/sfxSystem.h
+++ b/engine/source/sfx/sfxSystem.h
@@ -276,7 +276,6 @@ class SFXSystem
 #define SFX_DELETE( source )  \
    if ( source )              \
    {                          \
-      source->setPitch(1.0f); \
       source->deleteObject(); \
       source = NULL;          \
    }                          \


### PR DESCRIPTION
Loosely "fixes" #106, but more testing should be done to know for sure.

My crappy workaround was crappy. This one seems to work better - the problems I was facing before my original workaround didn't re-appear, and the way to reproduce the bug with the Skate Battle Royale trick seems to be fixed now as well.

This is _still_ just a workaround, but seems to make DirectSound work well for now. More effort should go into properly fixing this bug (or making OpenAL work for everyone), but this time I have ideas about where to look.