### PR TITLE
Fix end scores not showing up at the end of multiplayer sessions

### DIFF
--- a/engine/source/xblive/xbliveFunctions.cpp
+++ b/engine/source/xblive/xbliveFunctions.cpp
@@ -114,6 +114,29 @@ ConsoleFunction(XBLiveGetSignInPort, S32, 1, 1, "()")
     return 0;
 }
 
+bool xbliveSessionActive = false;
+
+ConsoleFunction(XBLiveIsStatsSessionActive, bool, 1, 1, "()")
+{
+    argc;
+
+    return xbliveSessionActive;
+}
+
+ConsoleFunction(XBLiveStartStatsSession, void, 1, 1, "()")
+{
+    argc;
+
+    xbliveSessionActive = true;
+}
+
+ConsoleFunction(XBLiveEndStatsSession, void, 1, 1, "()")
+{
+    argc;
+
+    xbliveSessionActive = false;
+}
+
 ConsoleFunction(PDLCAllowMission, bool, 2, 2, "(levelId)")
 {
     argc;

--- a/game/marble/client/scripts/game.cs
+++ b/game/marble/client/scripts/game.cs
@@ -942,7 +942,8 @@ function clientCmdSetGameState(%state, %data)
       // if we are in end state, write scores
       if (XBLiveIsStatsSessionActive() && (%state $= "end" || %state $= "wait"))
       {
-         if (%allowStats && $Client::currentGameCounts && %state $= "end")
+         //if (%allowStats && $Client::currentGameCounts && %state $= "end")
+         if (%state $= "end")
             clientWriteMultiplayerScores();
          echo("clientCmdSetGameState: Ending stats session and cleaning up stats");
          XBLiveEndStatsSession();

--- a/game/marble/client/scripts/game.cs
+++ b/game/marble/client/scripts/game.cs
@@ -733,7 +733,7 @@ function clientWriteMultiplayerScore(%client)
 
 function clientAreStatsAllowed()
 {
-   return !isDemoLaunch() && !isPCBuild() && XBLiveIsSignedInSilver() && $Client::UseXBLiveMatchMaking;
+   return !isDemoLaunch();// && !isPCBuild() && XBLiveIsSignedInSilver() && $Client::UseXBLiveMatchMaking;
 }
 
 function clientAreOfflineStatsAllowed()
@@ -942,8 +942,7 @@ function clientCmdSetGameState(%state, %data)
       // if we are in end state, write scores
       if (XBLiveIsStatsSessionActive() && (%state $= "end" || %state $= "wait"))
       {
-         //if (%allowStats && $Client::currentGameCounts && %state $= "end")
-         if (%state $= "end")
+         if (%allowStats && $Client::currentGameCounts && %state $= "end")
             clientWriteMultiplayerScores();
          echo("clientCmdSetGameState: Ending stats session and cleaning up stats");
          XBLiveEndStatsSession();


### PR DESCRIPTION
Fixes #100.

Note, there still seems to be an issue where the text is always white, rather than being colored black or orange when highlighted.

https://www.youtube.com/watch?v=DuXGb6rumew&t=323s