### PR TITLE
Fix crash in createTangents on size-only assemble pass

### DIFF
--- a/engine/source/ts/tsMesh.cpp
+++ b/engine/source/ts/tsMesh.cpp
@@ -3430,10 +3430,9 @@ void TSMesh::assemble(bool skip)
         // only do this if we copied the data...
         computeBounds();
 
-    createTangents();
-
-    if (meshType != SkinMeshType)
+    if (alloc.allocShape32(0) && meshType != SkinMeshType)
     {
+        createTangents();
         createVBIB();
     }
 }


### PR DESCRIPTION
The crash was happening because it was calculating tangents on the size-only pass, with no data actually loaded. So just don't do that.