### PR TITLE
Fix astrolabe freeze at very high fps

### DIFF
--- a/engine/source/ts/tsThread.cpp
+++ b/engine/source/ts/tsThread.cpp
@@ -330,7 +330,7 @@ void TSThread::setTimeScale(F32 ts)
 
 void TSThread::advancePos(F32 delta)
 {
-    if (mFabs(delta) > 0.00001f)
+    if (mFabs(delta) > 0.000001f)
     {
         // make dirty what this thread changes
         U32 dirtyFlags = sequence->dirtyFlags | (transitionData.inTransition ? TSShapeInstance::TransformDirty : 0);


### PR DESCRIPTION
This stops the astrolabe from visually freezing when at a very high fps (around 800+). 94d9ff9