### PR TITLE
Clamp angles when moving camera

### DIFF
--- a/engine/source/game/moveManager.cpp
+++ b/engine/source/game/moveManager.cpp
@@ -134,6 +134,12 @@ void Move::unclamp()
 
 void Move::clamp()
 {
+    // clamp before FANG2IANG, or else angles can become negative
+    const F32 angleClamp = M_PI_F - 0.000001f;
+    yaw = mClampF(yaw, -angleClamp, angleClamp);
+    pitch = mClampF(pitch, -angleClamp, angleClamp);
+    roll = mClampF(roll, -angleClamp, angleClamp);
+
     // angles are all 16 bit.
     pyaw = FANG2IANG(yaw);
     ppitch = FANG2IANG(pitch);


### PR DESCRIPTION
Fixes #113. This will limit the max speed of the camera. (Though not by more than the limit already [here](https://github.com/MBU-Team/OpenMBU/blob/c325ed59f1f41327b9df54d357bd388f12e76278/engine/source/game/marble/marblecamera.cpp#L109-L111))