### PR TITLE
Ensure linear texture filter is used when rendering GuiBitmapCtrl

### DIFF
--- a/engine/source/gui/controls/guiBitmapCtrl.cpp
+++ b/engine/source/gui/controls/guiBitmapCtrl.cpp
@@ -120,6 +120,9 @@ void GuiBitmapCtrl::onRender(Point2I offset, const RectI& updateRect)
 {
     if (mTextureObject)
     {
+        GFX->setTextureStageMagFilter(0, GFXTextureFilterLinear);
+        GFX->setTextureStageMinFilter(0, GFXTextureFilterLinear);
+
         GFX->clearBitmapModulation();
         if (mWrap)
         {


### PR DESCRIPTION
Fixes #114. This bug is also present in the Xbox 360 version.