### PR TITLE
Fix Menu Trigger callbacks

### DIFF
--- a/engine/source/gui/core/guiCanvas.cpp
+++ b/engine/source/gui/core/guiCanvas.cpp
@@ -688,7 +688,7 @@ bool GuiCanvas::processInputEvent(const InputEvent* event)
 
             return retval;
         } else {
-            Con::printf("Input fell outside current logic. Maybe theres a bug!");
+            Con::warnf("Input fell outside current logic. Event type: %d", event->objType);
         }
     }
 

--- a/engine/source/gui/core/guiCanvas.cpp
+++ b/engine/source/gui/core/guiCanvas.cpp
@@ -581,7 +581,6 @@ bool GuiCanvas::processInputEvent(const InputEvent* event)
 
         if (event->objType == SI_BUTTON || event->objType == SI_POV)
         {
-            Con::printf("Type was SI_BUTTON etc");
             if (event->action == SI_MAKE)
                 retval = responder->onGamepadButtonPressed(event->objInst);
             else if (event->action == SI_BREAK)

--- a/engine/source/gui/core/guiCanvas.cpp
+++ b/engine/source/gui/core/guiCanvas.cpp
@@ -573,14 +573,13 @@ bool GuiCanvas::processInputEvent(const InputEvent* event)
     else if (event->deviceType == XInputDeviceType)
     {
         // Do NOT PUT THE gLastEventTime change here, it will pick up the analog stick noise
-
         //copy the modifier into the new event
         mLastEvent.modifier = event->modifier;
-        
         bool retval = false;
 
         if (event->objType == SI_BUTTON || event->objType == SI_POV)
         {
+            Con::printf("Type was SI_BUTTON etc");
             if (event->action == SI_MAKE)
                 retval = responder->onGamepadButtonPressed(event->objInst);
             else if (event->action == SI_BREAK)
@@ -590,7 +589,7 @@ bool GuiCanvas::processInputEvent(const InputEvent* event)
             
             return retval;
         }
-        else if ((event->objType == XI_THUMBLY || event->objType == XI_THUMBLX) &&
+        else if ((event->objType == XI_THUMBLY || event->objType == XI_THUMBLX || event->objType == XI_LEFT_TRIGGER || event->objType == XI_RIGHT_TRIGGER) &&
             event->action == SI_MOVE && event->deviceInst < 4)
         {
             F32 incomingValue = mFabs(event->fValue);
@@ -601,19 +600,37 @@ bool GuiCanvas::processInputEvent(const InputEvent* event)
             static F32 yDecay[] = { 1.0f, 1.0f, 1.0f, 1.0f };
             static U32 xLastClickTime[] = { 0, 0, 0, 0 };
             static U32 yLastClickTime[] = { 0, 0, 0, 0 };
+
+            // Each trigger also needs decay/click logic
+            static F32 lDecay[] = { 1.0f, 1.0f, 1.0f, 1.0f };
+            static F32 rDecay[] = { 1.0f, 1.0f, 1.0f, 1.0f };
+            static U32 lLastClickTime[] = { 0, 0, 0, 0 };
+            static U32 rLastClickTime[] = { 0, 0, 0, 0 };
+
             U32 curTime = Platform::getRealMilliseconds();
             F32* decay;
             U32* lastClickTime;
 
+            // Determine the state for the respective analog value
             if (event->objType == XI_THUMBLX)
             {
                 decay = &xDecay[event->deviceInst];
                 lastClickTime = &xLastClickTime[event->deviceInst];
             }
-            else
+            else if (event->objType == XI_THUMBLY)
             {
                 decay = &yDecay[event->deviceInst];
                 lastClickTime = &yLastClickTime[event->deviceInst];
+            } 
+            else if (event->objType == XI_LEFT_TRIGGER) 
+            {
+                decay = &lDecay[event->deviceInst];
+                lastClickTime = &lLastClickTime[event->deviceInst];
+            } 
+            else if (event->objType == XI_RIGHT_TRIGGER) 
+            {
+                decay = &rDecay[event->deviceInst];
+                lastClickTime = &rLastClickTime[event->deviceInst];
             }
 
             //bool down = event->fValue < 0.f;
@@ -648,17 +665,27 @@ bool GuiCanvas::processInputEvent(const InputEvent* event)
                     else
                         retval = responder->onGamepadButtonPressed(XI_DPAD_UP);
                 }
-                else
+                else if (event->objType == XI_THUMBLX)
                 {
                     if (down)
                         retval = responder->onGamepadButtonPressed(XI_DPAD_RIGHT);
                     else
                         retval = responder->onGamepadButtonPressed(XI_DPAD_LEFT);
                 }
+                else if (event->objType == XI_LEFT_TRIGGER)
+                {
+                    retval = responder->onGamepadButtonPressed(XI_LEFT_TRIGGER);  
+                }
+                else if (event->objType == XI_RIGHT_TRIGGER)
+                {
+                    retval = responder->onGamepadButtonPressed(XI_RIGHT_TRIGGER);  
+                }
                 gLastEventTime = curTime;
             }
 
             return retval;
+        } else {
+            Con::printf("Input fell outside current logic. Maybe theres a bug!");
         }
     }
 

--- a/engine/source/gui/core/guiCanvas.cpp
+++ b/engine/source/gui/core/guiCanvas.cpp
@@ -573,8 +573,10 @@ bool GuiCanvas::processInputEvent(const InputEvent* event)
     else if (event->deviceType == XInputDeviceType)
     {
         // Do NOT PUT THE gLastEventTime change here, it will pick up the analog stick noise
+
         //copy the modifier into the new event
         mLastEvent.modifier = event->modifier;
+        
         bool retval = false;
 
         if (event->objType == SI_BUTTON || event->objType == SI_POV)
@@ -589,7 +591,8 @@ bool GuiCanvas::processInputEvent(const InputEvent* event)
             
             return retval;
         }
-        else if ((event->objType == XI_THUMBLY || event->objType == XI_THUMBLX || event->objType == XI_LEFT_TRIGGER || event->objType == XI_RIGHT_TRIGGER) &&
+        else if ((event->objType == XI_THUMBLY || event->objType == XI_THUMBLX || 
+            event->objType == XI_LEFT_TRIGGER || event->objType == XI_RIGHT_TRIGGER) &&
             event->action == SI_MOVE && event->deviceInst < 4)
         {
             F32 incomingValue = mFabs(event->fValue);
@@ -674,6 +677,7 @@ bool GuiCanvas::processInputEvent(const InputEvent* event)
                 }
                 else if (event->objType == XI_LEFT_TRIGGER)
                 {
+                    // Neither triggers care about the actual analog value, only if depressed
                     retval = responder->onGamepadButtonPressed(XI_LEFT_TRIGGER);  
                 }
                 else if (event->objType == XI_RIGHT_TRIGGER)


### PR DESCRIPTION
This PR adds handling and debouncing logic for the XInput triggers in the menus. This has been tested locally (by switching the `onLTrigger` to `onA` as well as printing), but if we need to add actual tests just let me know. 

Closes #152 