### PR TITLE
Fix tagged messages in MBU

### DIFF
--- a/engine/source/gui/core/guiCanvas.cpp
+++ b/engine/source/gui/core/guiCanvas.cpp
@@ -687,8 +687,6 @@ bool GuiCanvas::processInputEvent(const InputEvent* event)
             }
 
             return retval;
-        } else {
-            Con::warnf("Input fell outside current logic. Event type: %d", event->objType);
         }
     }
 

--- a/game/marble/client/scripts/game.cs
+++ b/game/marble/client/scripts/game.cs
@@ -1440,3 +1440,25 @@ function clientLocalizedItemPickupHandler( %msgType, %msgString, %id, %data )
    %message = powerupIdToString( %id,%data );
    addChatLine( %message );
 }
+
+//-------------------------------------------------------------------------------
+
+// Gem related msgs, also handles easter eggs
+
+addMessageCallback( 'MsgMissingGems', clientTaggedMessageHandler );
+addMessageCallBack( 'MsgItemPickup', clientTaggedMessageHandler );
+addMessageCallBack( 'MsgHaveAllGems', clientTaggedMessageHandler );
+addMessageCallBack( 'MsgRaceOver', clientTaggedMessageHandler );
+
+function clientTaggedMessageHandler(%msgType, %msgString, %id, %data)
+{
+   if (%msgType == 'MsgItemPickup') 
+   {
+      addChatLine(avar(detag(%msgString),%data));
+   } 
+   else 
+   {
+      addChatLine(detag(%msgString));
+   }
+
+}

--- a/game/marble/client/scripts/game.cs
+++ b/game/marble/client/scripts/game.cs
@@ -1452,13 +1452,7 @@ addMessageCallBack( 'MsgRaceOver', clientTaggedMessageHandler );
 
 function clientTaggedMessageHandler(%msgType, %msgString, %id, %data)
 {
-   if (%msgType == 'MsgItemPickup') 
-   {
-      addChatLine(avar(detag(%msgString),%data));
-   } 
-   else 
-   {
-      addChatLine(detag(%msgString));
-   }
-
+   // Detag the message and try to load any data into it as required. For strings not requiring config
+   // like "You've finished!" etc, avar is a no-op
+   addChatLine(avar(detag(%msgString),%data));
 }


### PR DESCRIPTION
Closes #172 

In Marble Blast Ultra, whenever a client receives a message from the server, first a generic callback is called for every callback not registered to a type (this being `onServerMessage` currently). This callback doesn't work properly for tagged messages ever since the MBO code got added, as the tagged messages are being treated as server messages to be rendered in the Chat Box (not as a tooltip like they were in the XBLA release). Nothing renders at all due to a faulty comparison in `game/cpmmon/client/message.cs` shown below:

```
function defaultMessageCallback(%msgType, %msgString, %a1, %a2, %a3, %a4, %a5, %a6, %a7, %a8, %a9, %a10)
{
   %msg = detag(%msgString);
   if (%msg !$= "" && %msg != 0) // %msg != 0 is faulty
      onServerMessage(%msg);
}
```

Regardless of this, rather than interfere with the client chat code (which is more complex than the original messaging functionality), this PR simply adds callbacks for the message types sent by a server when a gem/easter egg is picked up or the player touches an `EndPad`. The logic here simply detags the string and tries to load any additional data into it before correctly playing any sound effects and rendering text as required.