### PR TITLE
Memory-backed files in VFS

### DIFF
--- a/engine/source/atlas/atlasGen.cpp
+++ b/engine/source/atlas/atlasGen.cpp
@@ -301,7 +301,7 @@ S8 AtlasActivationHeightfield::checkPropagation(Point2I c, S8 level)
 
 bool AtlasActivationHeightfield::dumpActivationLevels(const char* filename)
 {
-    FileStream fs;
+    Stream* fs;
 
     if (!ResourceManager->openFileForWrite(fs, filename, File::ReadWrite))
     {
@@ -311,16 +311,16 @@ bool AtlasActivationHeightfield::dumpActivationLevels(const char* filename)
 
     for (S32 i = 0; i < size(); i++)
         for (S32 j = 0; j < size(); j++)
-            fs.write(getLevel(Point2I(i, j)));
+            fs->write(getLevel(Point2I(i, j)));
 
-    fs.close();
+    delete fs;
 
     return true;
 }
 
 bool AtlasActivationHeightfield::dumpHeightAtLOD(S8 level, const char* filename)
 {
-    FileStream fs;
+    Stream* fs;
 
     if (!ResourceManager->openFileForWrite(fs, filename, File::ReadWrite))
     {
@@ -336,11 +336,11 @@ bool AtlasActivationHeightfield::dumpHeightAtLOD(S8 level, const char* filename)
             const Point2I pos(i, j);
 
             HeightType h = getHeightAtLOD(pos, level);
-            fs.write(h);
+            fs->write(h);
         }
     }
 
-    fs.close();
+    delete fs;
 
     return true;
 }
@@ -938,7 +938,7 @@ ConsoleFunction(generateChunkFileFromRaw16, void, 8, 8, "(srcFile, size, squareS
     ResourceManager->closeStream(s);
 
     // Cool, it's loaded, try generating something.
-    FileStream fs;
+    Stream* fs;
 
     // Wipe it first.
     if (!ResourceManager->openFileForWrite(fs, destFile, File::Write))
@@ -947,7 +947,7 @@ ConsoleFunction(generateChunkFileFromRaw16, void, 8, 8, "(srcFile, size, squareS
         return;
     }
 
-    fs.close();
+    delete fs;
 
     // Now do it for reals.
     if (!ResourceManager->openFileForWrite(fs, destFile, File::ReadWrite))
@@ -956,9 +956,9 @@ ConsoleFunction(generateChunkFileFromRaw16, void, 8, 8, "(srcFile, size, squareS
         return;
     }
 
-    cahf.generateChunkFile(&fs, treeDepth, error);
+    cahf.generateChunkFile(fs, treeDepth, error);
 
-    fs.close();
+    delete fs;
 }
 
 ConsoleFunction(doChunkGen, void, 1, 1, "Test chunk generation.")
@@ -977,7 +977,7 @@ ConsoleFunction(doChunkGen, void, 1, 1, "Test chunk generation.")
     ResourceManager->closeStream(s);
 
     // Cool, it's loaded, try generating something.
-    FileStream fs;
+    Stream* fs;
 
     dFileDelete("demo/data/terrains/small.chu");
 
@@ -987,7 +987,7 @@ ConsoleFunction(doChunkGen, void, 1, 1, "Test chunk generation.")
         return;
     }
 
-    cahf.generateChunkFile(&fs, 5, 0.5f);
+    cahf.generateChunkFile(fs, 5, 0.5f);
 
-    fs.close();
+    delete fs;
 }

--- a/engine/source/atlas/atlasHeightfield.cpp
+++ b/engine/source/atlas/atlasHeightfield.cpp
@@ -131,7 +131,7 @@ bool AtlasHeightfield::saveJpeg(const char* filename)
         }
     }
 
-    FileStream fs;
+    Stream* fs;
 
     if (!ResourceManager->openFileForWrite(fs, filename, File::Write))
     {
@@ -139,8 +139,8 @@ bool AtlasHeightfield::saveJpeg(const char* filename)
         return false;
     }
 
-    tmp.writeJPEG(fs);
-    fs.close();
+    tmp.writeJPEG(*fs);
+    delete fs;
 
     return true;
 }

--- a/engine/source/atlas/atlasTQTFile.cpp
+++ b/engine/source/atlas/atlasTQTFile.cpp
@@ -441,7 +441,7 @@ void AtlasTQTFile::merge(AtlasTQTFile* tqt00, AtlasTQTFile* tqt01, AtlasTQTFile*
     dMemset(mOffsets.address(), 0, sizeof(mOffsets[0]) * mOffsets.size());
 
     // Open the file for output.
-    FileStream s;
+    Stream* s;
     if (!ResourceManager->openFileForWrite(s, outFile, File::ReadWrite))
     {
         Con::errorf("AtlasTQTFile::merge - could not open '%s' for generation (read AND write).", outFile);
@@ -449,14 +449,14 @@ void AtlasTQTFile::merge(AtlasTQTFile* tqt00, AtlasTQTFile* tqt01, AtlasTQTFile*
     }
 
     // Write a header. Some parts of this will get rewritten later (ie, the TOC)
-    s.write(4, "tqt\0");
-    s.write(mVersion);
-    s.write(mTreeDepth);
-    s.write(mTileSize);
+    s->write(4, "tqt\0");
+    s->write(mVersion);
+    s->write(mTreeDepth);
+    s->write(mTileSize);
 
-    U32 tocOffset = s.getPosition();
+    U32 tocOffset = s->getPosition();
 
-    s.write(sizeof(mOffsets[0]) * mOffsets.size(), mOffsets.address());
+    s->write(sizeof(mOffsets[0]) * mOffsets.size(), mOffsets.address());
 
     // Ok, copy everything from the children.
     copy(tqt00, s, 0, Point2I(0, 0), 1, Point2I(0, 0));
@@ -469,12 +469,12 @@ void AtlasTQTFile::merge(AtlasTQTFile* tqt00, AtlasTQTFile* tqt01, AtlasTQTFile*
     generateInnerTiles(s);
 
     // Update the TOC.
-    s.setPosition(tocOffset);
+    s->setPosition(tocOffset);
     for (S32 i = 0; i < mOffsets.size(); i++)
-        s.write(mOffsets[i]);
+        s->write(mOffsets[i]);
 
     // Finally, close up.
-    s.close();
+    delete s;
 }
 
 void AtlasTQTFile::createTQT(const char* sourceImage, const char* outputTQT, U32 treeDepth, U32 tileSize)
@@ -511,7 +511,7 @@ void AtlasTQTFile::createTQT(const char* sourceImage, const char* outputTQT, U32
     dMemset(mOffsets.address(), 0, sizeof(mOffsets[0]) * mOffsets.size());
 
     // Open the file for output.
-    FileStream s;
+    Stream* s;
     if (!ResourceManager->openFileForWrite(s, outputTQT, File::ReadWrite))
     {
         Con::errorf("AtlasTQTFile::createTQT - could not open '%s' for generation (read AND write).", outputTQT);
@@ -519,14 +519,14 @@ void AtlasTQTFile::createTQT(const char* sourceImage, const char* outputTQT, U32
     }
 
     // Write a header. Some parts of this will get rewritten later (ie, the TOC)
-    s.write(4, "tqt\0");
-    s.write(mVersion);
-    s.write(mTreeDepth);
-    s.write(mTileSize);
+    s->write(4, "tqt\0");
+    s->write(mVersion);
+    s->write(mTreeDepth);
+    s->write(mTileSize);
 
-    U32 tocOffset = s.getPosition();
+    U32 tocOffset = s->getPosition();
 
-    s.write(sizeof(mOffsets[0]) * mOffsets.size(), mOffsets.address());
+    s->write(sizeof(mOffsets[0]) * mOffsets.size(), mOffsets.address());
 
     // Allocate space for the row working area which is equal to the height of
     // a tile, and also load in the first chunk's worth of data.
@@ -592,14 +592,14 @@ void AtlasTQTFile::createTQT(const char* sourceImage, const char* outputTQT, U32
     delete[] tileWorkspace;
 
     // Update the TOC.
-    s.setPosition(tocOffset);
+    s->setPosition(tocOffset);
     for (S32 i = 0; i < mOffsets.size(); i++)
-        s.write(mOffsets[i]);
+        s->write(mOffsets[i]);
 
     // Finally, close the reader and the TQT file.
 
     reader.close();
-    s.close();
+    delete s;
 }
 
 

--- a/engine/source/atlas/core/atlasFile.cpp
+++ b/engine/source/atlas/core/atlasFile.cpp
@@ -82,7 +82,7 @@ bool AtlasFile::createNew(const char* filename)
 {
     // Blank the file if it exists.
     {
-        FileStream fs;
+        Stream* fs;
 
         // Wipe it first.
         if (!ResourceManager->openFileForWrite(fs, filename, File::Write))
@@ -92,7 +92,7 @@ bool AtlasFile::createNew(const char* filename)
             return false;
         }
 
-        fs.close();
+        delete fs;
     }
 
     // Initialize our stream.

--- a/engine/source/atlas/editor/atlasOldGenerator.cpp
+++ b/engine/source/atlas/editor/atlasOldGenerator.cpp
@@ -298,7 +298,7 @@ S8 AtlasOldActivationHeightfield::checkPropagation(Point2I c, S8 level)
 
 bool AtlasOldActivationHeightfield::dumpActivationLevels(const char* filename)
 {
-    FileStream fs;
+    Stream* fs;
 
     if (!ResourceManager->openFileForWrite(fs, filename, File::ReadWrite))
     {
@@ -308,16 +308,16 @@ bool AtlasOldActivationHeightfield::dumpActivationLevels(const char* filename)
 
     for (S32 i = 0; i < size(); i++)
         for (S32 j = 0; j < size(); j++)
-            fs.write(getLevel(Point2I(i, j)));
+            fs->write(getLevel(Point2I(i, j)));
 
-    fs.close();
+    delete fs;
 
     return true;
 }
 
 bool AtlasOldActivationHeightfield::dumpHeightAtLOD(S8 level, const char* filename)
 {
-    FileStream fs;
+    Stream* fs;
 
     if (!ResourceManager->openFileForWrite(fs, filename, File::ReadWrite))
     {
@@ -333,11 +333,11 @@ bool AtlasOldActivationHeightfield::dumpHeightAtLOD(S8 level, const char* filena
             const Point2I pos(i, j);
 
             HeightType h = getHeightAtLOD(pos, level);
-            fs.write(h);
+            fs->write(h);
         }
     }
 
-    fs.close();
+    delete fs;
 
     return true;
 }
@@ -935,7 +935,7 @@ ConsoleFunction(atlasOldGenerateChunkFileFromRaw16, void, 8, 8, "(srcFile, size,
     ResourceManager->closeStream(s);
 
     // Cool, it's loaded, try generating something.
-    FileStream fs;
+    Stream* fs;
 
     // Wipe it first.
     if (!ResourceManager->openFileForWrite(fs, destFile, File::Write))
@@ -944,7 +944,7 @@ ConsoleFunction(atlasOldGenerateChunkFileFromRaw16, void, 8, 8, "(srcFile, size,
         return;
     }
 
-    fs.close();
+    delete fs;
 
     // Now do it for reals.
     if (!ResourceManager->openFileForWrite(fs, destFile, File::ReadWrite))
@@ -953,7 +953,7 @@ ConsoleFunction(atlasOldGenerateChunkFileFromRaw16, void, 8, 8, "(srcFile, size,
         return;
     }
 
-    cahf.generateChunkFile(&fs, treeDepth, error);
+    cahf.generateChunkFile(fs, treeDepth, error);
 
-    fs.close();
+    delete fs;
 }

--- a/engine/source/atlas/editor/atlasOldHeightfield.cpp
+++ b/engine/source/atlas/editor/atlasOldHeightfield.cpp
@@ -129,7 +129,7 @@ bool AtlasOldHeightfield::saveJpeg(const char* filename)
         }
     }
 
-    FileStream fs;
+    Stream* fs;
 
     if (!ResourceManager->openFileForWrite(fs, filename, File::Write))
     {
@@ -137,8 +137,8 @@ bool AtlasOldHeightfield::saveJpeg(const char* filename)
         return false;
     }
 
-    tmp.writeJPEG(fs);
-    fs.close();
+    tmp.writeJPEG(*fs);
+    delete fs;
 
     return true;
 }

--- a/engine/source/console/codeBlock.cpp
+++ b/engine/source/console/codeBlock.cpp
@@ -431,10 +431,10 @@ bool CodeBlock::compile(const char* codeFileName, StringTableEntry fileName, con
         return false;
     }
 
-    FileStream st;
+    Stream* st;
     if (!ResourceManager->openFileForWrite(st, codeFileName))
         return false;
-    st.write(U32(Con::DSOVersion));
+    st->write(U32(Con::DSOVersion));
 
     // Reset all our value tables...
     resetTables();
@@ -454,12 +454,12 @@ bool CodeBlock::compile(const char* codeFileName, StringTableEntry fileName, con
     lineBreakPairs = code + codeSize;
 
     // Write string table data...
-    getGlobalStringTable().write(st);
-    getFunctionStringTable().write(st);
+    getGlobalStringTable().write(*st);
+    getFunctionStringTable().write(*st);
 
     // Write float table data...
-    getGlobalFloatTable().write(st);
-    getFunctionFloatTable().write(st);
+    getGlobalFloatTable().write(*st);
+    getFunctionFloatTable().write(*st);
 
     smBreakLineCount = 0;
     U32 lastIp;
@@ -473,30 +473,30 @@ bool CodeBlock::compile(const char* codeFileName, StringTableEntry fileName, con
 
     code[lastIp++] = OP_RETURN;
     U32 totSize = codeSize + smBreakLineCount * 2;
-    st.write(codeSize);
-    st.write(lineBreakPairCount);
+    st->write(codeSize);
+    st->write(lineBreakPairCount);
 
     // Write out our bytecode, doing a bit of compression for low numbers.
     U32 i;
     for (i = 0; i < codeSize; i++)
     {
         if (code[i] < 0xFF)
-            st.write(U8(code[i]));
+            st->write(U8(code[i]));
         else
         {
-            st.write(U8(0xFF));
-            st.write((U32)code[i]);
+            st->write(U8(0xFF));
+            st->write((U32)code[i]);
         }
     }
 
     // Write the break info...
     for (i = codeSize; i < totSize; i++)
-        st.write((U32)code[i]);
+        st->write((U32)code[i]);
 
-    getIdentTable().write(st);
+    getIdentTable().write(*st);
 
     consoleAllocReset();
-    st.close();
+    delete st;
 
     return true;
 }

--- a/engine/source/console/consoleInternal.cpp
+++ b/engine/source/console/consoleInternal.cpp
@@ -129,7 +129,7 @@ void Dictionary::exportVariables(const char* varString, const char* fileName, bo
 
     Vector<Entry*>::iterator s;
     char expandBuffer[1024];
-    FileStream strm;
+    Stream* strm;
 
     if (fileName)
     {
@@ -139,7 +139,7 @@ void Dictionary::exportVariables(const char* varString, const char* fileName, bo
             return;
         }
         if (append)
-            strm.setPosition(strm.getStreamSize());
+            strm->setPosition(strm->getStreamSize());
     }
 
     char buffer[1024];
@@ -196,12 +196,12 @@ void Dictionary::exportVariables(const char* varString, const char* fileName, bo
             break;
         }
         if (fileName)
-            strm.write(dStrlen(buffer), buffer);
+            strm->write(dStrlen(buffer), buffer);
         else
             Con::printf("%s", buffer);
     }
     if (fileName)
-        strm.close();
+        delete strm;
 }
 
 void Dictionary::deleteVariables(const char* varString, bool emptyOnly)

--- a/engine/source/console/simBase.cpp
+++ b/engine/source/console/simBase.cpp
@@ -560,7 +560,7 @@ ConsoleMethod(SimObject, save, bool, 3, 4, "obj.save(fileName, <selectedOnly>)")
 {
     static const char* beginMessage = "//--- OBJECT WRITE BEGIN ---";
     static const char* endMessage = "//--- OBJECT WRITE END ---";
-    FileStream stream;
+    Stream* stream;
     FileObject f;
     f.readMemory(argv[2]);
 
@@ -597,14 +597,14 @@ ConsoleMethod(SimObject, save, bool, 3, 4, "obj.save(fileName, <selectedOnly>)")
         buffer = (const char*)f.readLine();
         if (!dStrcmp(buffer, beginMessage))
             break;
-        stream.write(dStrlen(buffer), buffer);
-        stream.write(2, "\r\n");
+        stream->write(dStrlen(buffer), buffer);
+        stream->write(2, "\r\n");
     }
-    stream.write(dStrlen(beginMessage), beginMessage);
-    stream.write(2, "\r\n");
-    object->write(stream, 0, writeFlags);
-    stream.write(dStrlen(endMessage), endMessage);
-    stream.write(2, "\r\n");
+    stream->write(dStrlen(beginMessage), beginMessage);
+    stream->write(2, "\r\n");
+    object->write(*stream, 0, writeFlags);
+    stream->write(dStrlen(endMessage), endMessage);
+    stream->write(2, "\r\n");
     while (!f.isEOF())
     {
         buffer = (const char*)f.readLine();
@@ -614,12 +614,14 @@ ConsoleMethod(SimObject, save, bool, 3, 4, "obj.save(fileName, <selectedOnly>)")
     while (!f.isEOF())
     {
         buffer = (const char*)f.readLine();
-        stream.write(dStrlen(buffer), buffer);
-        stream.write(2, "\r\n");
+        stream->write(dStrlen(buffer), buffer);
+        stream->write(2, "\r\n");
     }
 
     Con::setVariable("$DocRoot", NULL);
     Con::setVariable("$ModRoot", NULL);
+    
+    delete stream;
 
     return true;
 }

--- a/engine/source/core/chunkFile.cpp
+++ b/engine/source/core/chunkFile.cpp
@@ -22,7 +22,7 @@ bool ChunkFile::save(const char* filename)
     gChunkBuffer.reset();
 
     // Get a stream...
-    FileStream s;
+    Stream* s;
     if (!ResourceManager->openFileForWrite(s, filename))
     {
         Con::errorf("ChunkFile::save - cannot open '%s' for write.", filename);
@@ -30,15 +30,17 @@ bool ChunkFile::save(const char* filename)
     }
 
     // write preamble!
-    s.write(csmFileFourCC);
-    s.write(csmFileVersion);
+    s->write(csmFileFourCC);
+    s->write(csmFileVersion);
 
     // Now save out the chunks!
-    saveInner(s, getRoot());
+    saveInner(*s, getRoot());
 
     // Free any memory we had to use for buffering.
     gChunkBuffer.reset();
     gChunkBuffer.compact();
+
+    delete s;
 
     // All done!
     return true;

--- a/engine/source/core/fileObject.h
+++ b/engine/source/core/fileObject.h
@@ -22,7 +22,7 @@ class FileObject : public SimObject
     U8* mFileBuffer;
     U32 mBufferSize;
     U32 mCurPos;
-    FileStream stream;
+    Stream* mStream;
 public:
     FileObject();
     ~FileObject();

--- a/engine/source/core/memstream.h
+++ b/engine/source/core/memstream.h
@@ -18,7 +18,7 @@ class MemStream : public Stream {
     typedef Stream Parent;
 
 protected:
-    U32 const cm_bufferSize;
+    U32 m_bufferSize;
     void* m_pBufferBase;
     bool mOwnsMemory;
 
@@ -46,9 +46,9 @@ public:
     U32  getStreamSize();
     inline bool checkStatus(U32 bytes)
     {
-        if (m_currentPosition + bytes > cm_bufferSize)
+        if (m_currentPosition + bytes > m_bufferSize)
         {
-            m_currentPosition = cm_bufferSize;
+            m_currentPosition = m_bufferSize;
             setStatus(EOS);
             return false;
         }
@@ -163,6 +163,51 @@ public:
         *dest = temp;
         return ret;
     }
+};
+
+class ResizableMemStream : public MemStream {
+    typedef MemStream Parent;
+
+    U32 m_filledSize;
+    bool expandToSize(U32 size);
+
+public:
+    ResizableMemStream(const U32 in_bufferSize = 0,
+        void* io_pBuffer = NULL,
+        const bool in_allowRead = true,
+        const bool in_allowWrite = true);
+    virtual ~ResizableMemStream();
+
+    virtual U32 getStreamSize();
+    virtual bool setPosition(const U32 in_newPosition);
+    virtual bool _write(const U32 in_numBytes, const void* in_pBuffer);
+};
+
+class MemSubStream : public Stream {
+    typedef Stream Parent;
+
+    Stream* m_pStream;
+    U32 m_currOffset;
+
+public:
+    MemSubStream();
+    ~MemSubStream();
+
+    bool attachStream(Stream* io_pSlaveStream);
+    void detachStream();
+    Stream* getStream();
+
+protected:
+    bool _read(const U32 in_numBytes, void* out_pBuffer);
+    bool _write(const U32 in_numBytes, const void* in_pBuffer);
+
+public:
+    bool hasCapability(const Capability) const;
+
+    U32 getPosition() const;
+    bool setPosition(const U32 in_newPosition);
+
+    U32 getStreamSize();
 };
 
 #endif //_MEMSTREAM_H_

--- a/engine/source/core/resManager.cpp
+++ b/engine/source/core/resManager.cpp
@@ -1207,7 +1207,7 @@ void ResManager::freeResource(ResourceObject* ro)
 
 //------------------------------------------------------------------------------
 
-bool ResManager::openFileForWrite(FileStream& stream, const char* fileName, U32 accessMode)
+bool ResManager::openFileForWrite(Stream*& stream, const char* fileName, U32 accessMode)
 {
     if (!isValidWriteFileName(fileName))
         return false;
@@ -1222,8 +1222,14 @@ bool ResManager::openFileForWrite(FileStream& stream, const char* fileName, U32 
 
     if (!Platform::createPath(fileName))   // create directory tree
         return false;
-    if (!stream.open(fileName, (FileStream::AccessMode)accessMode))
+
+    FileStream* fs = new FileStream();
+    if (!fs->open(fileName, (FileStream::AccessMode)accessMode))
+    {
+        delete fs;
         return false;
+    }
+    stream = fs;
 
     // create a resource for the file.
     ResourceObject* ro = createResource(StringTable->insert(path), StringTable->insert(file));

--- a/engine/source/core/resManager.h
+++ b/engine/source/core/resManager.h
@@ -16,9 +16,6 @@
 #include "core/stringTable.h"
 #endif
 
-#ifndef _FILESTREAM_H_
-#include "core/fileStream.h"
-#endif
 #ifndef _ZIPSUBSTREAM_H_
 #include "core/zipSubStream.h"
 #endif
@@ -33,7 +30,6 @@
 #endif
 
 class Stream;
-class FileStream;
 class ZipSubRStream;
 class ResManager;
 class FindMatch;
@@ -456,7 +452,7 @@ public:
     bool isValidWriteFileName(const char* fn);         ///< Checks to see if the given path is valid for writing.
 
     /// Opens a file for writing!
-    bool openFileForWrite(FileStream& fs, const char* fileName, U32 accessMode = 1);
+    bool openFileForWrite(Stream*& fs, const char* fileName, U32 accessMode = 1);
 
     void startResourceTraverse();
     ResourceObject* getNextResource();

--- a/engine/source/core/resManager.h
+++ b/engine/source/core/resManager.h
@@ -129,6 +129,7 @@ public:
         VolumeBlock = BIT(0),
         File = BIT(1),
         Added = BIT(2),
+        Memory = BIT(3),
     };
     S32 flags;  ///< Set from Flags.
 
@@ -146,6 +147,14 @@ public:
     S32 fileOffset;            ///< Offset of data in zip file.
     S32 fileSize;              ///< Size on disk of resource block.
     S32 compressedFileSize;    ///< Actual size of resource data.
+    /// @}
+
+    /// @name Memory Stream
+    /// If the resource is stored in memory, these members are populated
+    /// @{
+
+    class ResizableMemStream* mMemStream;
+
     /// @}
 
     ResourceInstance* mInstance;  ///< Pointer to actual object instance. If the object is not loaded,

--- a/engine/source/editor/terrain/terraformer.cpp
+++ b/engine/source/editor/terrain/terraformer.cpp
@@ -319,7 +319,7 @@ bool Terraformer::loadGreyscale(U32 r, const char* filename)
 //------------------------------------------------------------------------------
 bool Terraformer::saveHeightField(U32 r, const char* filename)
 {
-    FileStream stream;
+    Stream* stream;
     F32 fmin, fmax, f;
     Heightfield* dst = getRegister(r);
 
@@ -333,9 +333,9 @@ bool Terraformer::saveHeightField(U32 r, const char* filename)
             {
                 f = (dst->val(wrap((S32)(x + mShift.x)), wrap((S32)(y + mShift.y))) - fmin) * scale;
                 U16 test = floatToFixed(f);
-                stream.write(test);
+                stream->write(test);
             }
-        stream.close();
+        delete stream;
     }
 
     return true;

--- a/engine/source/game/banList.cpp
+++ b/engine/source/game/banList.cpp
@@ -119,7 +119,7 @@ bool BanList::isTAEq(const char* bannedTA, const char* TA)
 
 void BanList::exportToFile(const char* name)
 {
-    FileStream banlist;
+    Stream* banlist;
 
     char filename[1024];
     Con::expandScriptFilename(filename, sizeof(filename), name);
@@ -130,11 +130,11 @@ void BanList::exportToFile(const char* name)
         for (i = list.begin(); i != list.end(); i++)
         {
             dSprintf(buf, sizeof(buf), "BanList::addAbsolute(%d, \"%s\", %d);\r\n", i->uniqueId, i->transportAddress, i->bannedUntil);
-            banlist.write(dStrlen(buf), buf);
+            banlist->write(dStrlen(buf), buf);
         }
     }
 
-    banlist.close();
+    delete banlist;
 }
 
 // ---------------------------------------------------------

--- a/engine/source/gfx/bitmapPng.cpp
+++ b/engine/source/gfx/bitmapPng.cpp
@@ -475,7 +475,7 @@ bool GBitmap::writePNGDebug(char* name) const
         U32 waterMark = FrameAllocator::getWaterMark();
         dSprintf(bitmapNameBuf, sizeof(bitmapNameBuf), "demo/%s_%d.png", name, i);
         Con::printf("Writing texture to : '%s'", bitmapNameBuf);
-        FileStream stream;
+        Stream* stream;
 
         if (ResourceManager->openFileForWrite(stream, bitmapNameBuf))
         {
@@ -502,7 +502,7 @@ bool GBitmap::writePNGDebug(char* name) const
                 return false;
             }
 
-            png_set_write_fn(png_ptr, &stream, pngWriteDataFn, pngFlushDataFn);
+            png_set_write_fn(png_ptr, stream, pngWriteDataFn, pngFlushDataFn);
 
             // Set the compression level, image filters, and compression strategy...
             png_ptr->flags |= PNG_FLAG_ZLIB_CUSTOM_STRATEGY;
@@ -552,7 +552,7 @@ bool GBitmap::writePNGDebug(char* name) const
             png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
 
             // Close stream
-            stream.close();
+            delete stream;
         }
 
         FrameAllocator::setWaterMark(waterMark);

--- a/engine/source/gfx/gNewFont.cpp
+++ b/engine/source/gfx/gNewFont.cpp
@@ -134,12 +134,12 @@ ConsoleFunction(writeFontCache, void, 1, 1, "() - force all cached fonts to"
         }
 
         // Ok, dump info!
-        FileStream stream;
+        Stream* stream;
         if (ResourceManager->openFileForWrite(stream, curMatch))
         {
             Con::printf("      o Writing '%s' to disk...", curMatch);
-            font->write(stream);
-            stream.close();
+            font->write(*stream);
+            delete stream;
         }
         else
         {
@@ -296,12 +296,12 @@ ConsoleFunction(duplicateCachedFont, void, 4, 4, "(oldFontName, oldFontSize, new
     }
 
     // Ok, dump info!
-    FileStream stream;
+    Stream* stream;
     if (ResourceManager->openFileForWrite(stream, newFontFile))
     {
         Con::printf("      o Writing duplicate font '%s' to disk...", newFontFile);
-        font->write(stream);
-        stream.close();
+        font->write(*stream);
+        delete stream;
     }
     else
     {
@@ -430,11 +430,11 @@ GFont::~GFont()
 
         if (!noBitmap)
         {
-            FileStream stream;
+            Stream* stream;
             if (ResourceManager->openFileForWrite(stream, mGFTFile))
             {
-                write(stream);
-                stream.close();
+                write(*stream);
+                delete stream;
             }
         }
     }*/
@@ -1046,7 +1046,7 @@ void GFont::exportStrip(const char* fileName, U32 padding, U32 kerning)
     }
 
     // Write the image!
-    FileStream fs;
+    Stream* fs;
 
     if (!ResourceManager->openFileForWrite(fs, fileName))
     {
@@ -1055,7 +1055,8 @@ void GFont::exportStrip(const char* fileName, U32 padding, U32 kerning)
     }
 
     // Done!
-    gb.writePNG(fs, false);
+    gb.writePNG(*fs, false);
+    delete fs;
 }
 
 /// Used for repacking in GFont::importStrip.

--- a/engine/source/gfx/gfxDevice.cpp
+++ b/engine/source/gfx/gfxDevice.cpp
@@ -17,6 +17,7 @@
 #include "gfx/gNewFont.h"
 #include "platform/profiler.h"
 #include "core/unicode.h"
+#include "core/fileStream.h"
 
 Vector<GFXDevice*> GFXDevice::smGFXDevice;
 S32 GFXDevice::smActiveDeviceIndex = -1;
@@ -2133,7 +2134,7 @@ void GFXDevice::_dumpStatesToFile( const char *fileName ) const
    dSprintf( nameBuffer, sizeof(nameBuffer), "demo/%s_%d.gfxstate", fileName, stateDumpNum );
 
 
-   FileStream stream;
+   Stream* stream;
 
    if( ResourceManager->openFileForWrite( stream, nameBuffer ) )
    {
@@ -2144,25 +2145,26 @@ void GFXDevice::_dumpStatesToFile( const char *fileName ) const
       stateDumpNum++;
 
       // Dump render states
-      stream.writeLine( (U8 *)"Render States" );
+      stream->writeLine( (U8 *)"Render States" );
       for( U32 state = GFXRenderState_FIRST; state < GFXRenderState_COUNT; state++ )
-         stream.writeLine( (U8 *)avar( "%s - %s", GFXStringRenderState[state], GFXStringRenderStateValueLookup[state]( mStateTracker[state].newValue ) ) );
+         stream->writeLine( (U8 *)avar( "%s - %s", GFXStringRenderState[state], GFXStringRenderStateValueLookup[state]( mStateTracker[state].newValue ) ) );
 
       // Dump texture stage states
       for( U32 stage = 0; stage < getNumSamplers(); stage++ )
       {
-         stream.writeLine( (U8 *)avar( "Texture Stage: %d", stage ) );
+         stream->writeLine( (U8 *)avar( "Texture Stage: %d", stage ) );
          for( U32 state = GFXTSS_FIRST; state < GFXTSS_COUNT; state++ )
-            stream.writeLine( (U8 *)avar( "::%s - %s", GFXStringTextureStageState[state], GFXStringTextureStageStateValueLookup[state]( mTextureStateTracker[stage][state].newValue ) ) );
+            stream->writeLine( (U8 *)avar( "::%s - %s", GFXStringTextureStageState[state], GFXStringTextureStageStateValueLookup[state]( mTextureStateTracker[stage][state].newValue ) ) );
       }
 
       // Dump sampler states
       for( U32 stage = 0; stage < getNumSamplers(); stage++ )
       {
-         stream.writeLine( (U8 *)avar( "Sampler Stage: %d\n", stage ) );
+         stream->writeLine( (U8 *)avar( "Sampler Stage: %d\n", stage ) );
          for( U32 state = GFXSAMP_FIRST; state < GFXSAMP_COUNT; state++ )
-            stream.writeLine( (U8 *)avar( "::%s - %s", GFXStringSamplerState[state], GFXStringSamplerStateValueLookup[state]( mSamplerStateTracker[stage][state].newValue ) ) );
+            stream->writeLine( (U8 *)avar( "::%s - %s", GFXStringSamplerState[state], GFXStringSamplerStateValueLookup[state]( mSamplerStateTracker[stage][state].newValue ) ) );
       }
+      delete stream;
    }
 #endif
 }

--- a/engine/source/gui/editor/guiEditCtrl.cpp
+++ b/engine/source/gui/editor/guiEditCtrl.cpp
@@ -999,7 +999,7 @@ void GuiEditCtrl::saveSelection(const char* filename)
     if (mSelectedControls.size() == 0)
         return;
 
-    FileStream stream;
+    Stream* stream;
     if (!ResourceManager->openFileForWrite(stream, filename))
         return;
     SimSet* clipboardSet = new SimSet;
@@ -1010,8 +1010,9 @@ void GuiEditCtrl::saveSelection(const char* filename)
     for (i = mSelectedControls.begin(); i != mSelectedControls.end(); i++)
         clipboardSet->addObject(*i);
 
-    clipboardSet->write(stream, 0);
+    clipboardSet->write(*stream, 0);
     clipboardSet->deleteObject();
+    delete stream;
 }
 
 void GuiEditCtrl::selectAll()

--- a/engine/source/i18n/lang.cpp
+++ b/engine/source/i18n/lang.cpp
@@ -82,7 +82,7 @@ bool LangFile::load(Stream* s)
 
 bool LangFile::save(const UTF8* filename)
 {
-    FileStream fs;
+    Stream* fs;
     bool bRet = false;
 
     if (!isLoaded())
@@ -90,8 +90,8 @@ bool LangFile::save(const UTF8* filename)
 
     if (ResourceManager->openFileForWrite(fs, (const char*)filename))
     {
-        bRet = save(&fs);
-        fs.close();
+        bRet = save(fs);
+        delete fs;
     }
     return bRet;
 }

--- a/engine/source/lightingSystem/sgSceneLighting.cc
+++ b/engine/source/lightingSystem/sgSceneLighting.cc
@@ -642,12 +642,13 @@ bool SceneLighting::light(BitSet32 flags)
     // don't light if file is read-only?
     if (!flags.test(ForceAlways))
     {
-        FileStream fileStream;
+        Stream* fileStream;
         if (!ResourceManager->openFileForWrite(fileStream, mFileName))
         {
             Con::errorf(ConsoleLogEntry::General, "SceneLighting::Light: Failed to light mission.  File '%s' cannot be written to.", mFileName);
             return(false);
         }
+        delete fileStream;
     }
 
     // initialize the objects for lighting
@@ -887,7 +888,7 @@ bool SceneLighting::loadPersistInfo(const char* fileName)
 bool SceneLighting::savePersistInfo(const char* fileName)
 {
     // open the file
-    FileStream file;
+    Stream* file;
     if (!ResourceManager->openFileForWrite(file, fileName))
         return(false);
 
@@ -920,10 +921,10 @@ bool SceneLighting::savePersistInfo(const char* fileName)
             return(false);
     }
 
-    if (!persistInfo.write(file))
+    if (!persistInfo.write(*file))
         return(false);
 
-    file.close();
+    delete file;
 
     // open/close the stream to get the fileSize calculated on the resource object
     ResourceManager->closeStream(ResourceManager->openStream(fileName));

--- a/engine/source/sim/actionMap.cpp
+++ b/engine/source/sim/actionMap.cpp
@@ -84,7 +84,7 @@ void ActionMap::dumpActionMap(const char* fileName, const bool append) const
         // Dump the deletion, and creation script commands, followed by all the binds
         //  to a script.
 
-        FileStream iostrm;
+        Stream* iostrm;
         if (!ResourceManager->openFileForWrite(iostrm, fileName, append ? FileStream::WriteAppend : FileStream::Write))
         {
             Con::errorf("Unable to open file '%s' for writing.", fileName);
@@ -93,17 +93,17 @@ void ActionMap::dumpActionMap(const char* fileName, const bool append) const
 
         char lineBuffer[1024];
         if (append)
-            iostrm.setPosition(iostrm.getStreamSize());
+            iostrm->setPosition(iostrm->getStreamSize());
         else
         {
             // IMPORTANT -- do NOT change the following line, it identifies the file as an input map file
             dStrcpy(lineBuffer, "// Torque Input Map File\n");
-            iostrm.write(dStrlen(lineBuffer), lineBuffer);
+            iostrm->write(dStrlen(lineBuffer), lineBuffer);
         }
 
         dSprintf(lineBuffer, 1023, "%s.delete();\n"
             "new ActionMap(%s);\n", getName(), getName());
-        iostrm.write(dStrlen(lineBuffer), lineBuffer);
+        iostrm->write(dStrlen(lineBuffer), lineBuffer);
 
         // Dump all the binds to the console...
         for (S32 i = 0; i < mDeviceMaps.size(); i++) {
@@ -184,11 +184,11 @@ void ActionMap::dumpActionMap(const char* fileName, const bool append) const
                 }
 
                 dStrcat(lineBuffer, ");\n");
-                iostrm.write(dStrlen(lineBuffer), lineBuffer);
+                iostrm->write(dStrlen(lineBuffer), lineBuffer);
             }
         }
 
-        iostrm.close();
+        delete iostrm;
     }
     else {
         // Dump all the binds to the console...

--- a/engine/source/sim/netConnection.cpp
+++ b/engine/source/sim/netConnection.cpp
@@ -757,9 +757,9 @@ bool NetConnection::readDemoStartBlock(BitStream* stream)
 
 bool NetConnection::startDemoRecord(const char* fileName)
 {
-    FileStream* fs = new FileStream;
+    Stream* fs;
 
-    if (!ResourceManager->openFileForWrite(*fs, fileName))
+    if (!ResourceManager->openFileForWrite(fs, fileName))
     {
         delete fs;
         return false;

--- a/engine/source/sim/netDownload.cpp
+++ b/engine/source/sim/netDownload.cpp
@@ -1021,7 +1021,7 @@ void NetConnection::chunkReceived(U8* chunkData, U32 chunkLen)
     {
         // this file's done...
         // save it to disk:
-        FileStream stream;
+        Stream* stream;
 
         Con::printf("Saving file %s.", mMissingFileList[0]);
         if (!ResourceManager->openFileForWrite(stream, mMissingFileList[0]))
@@ -1031,8 +1031,8 @@ void NetConnection::chunkReceived(U8* chunkData, U32 chunkLen)
         }
         dFree(mMissingFileList[0]);
         mMissingFileList.pop_front();
-        stream.write(mCurrentFileBufferSize, mCurrentFileBuffer);
-        stream.close();
+        stream->write(mCurrentFileBufferSize, mCurrentFileBuffer);
+        delete stream;
         mNumDownloadedFiles++;
         dFree(mCurrentFileBuffer);
         mCurrentFileBuffer = NULL;

--- a/engine/source/terrain/terrData.cpp
+++ b/engine/source/terrain/terrData.cpp
@@ -1192,14 +1192,14 @@ const char* TerrainFile::getHeightfieldScript()
 //--------------------------------------
 bool TerrainFile::save(const char* filename)
 {
-    FileStream writeFile;
+    Stream* writeFile;
     if (!ResourceManager->openFileForWrite(writeFile, filename))
         return false;
 
     // write the VERSION and HeightField
-    writeFile.write((U8)FILE_VERSION);
+    writeFile->write((U8)FILE_VERSION);
     for (S32 i = 0; i < (TerrainBlock::BlockSize * TerrainBlock::BlockSize); i++)
-        writeFile.write(mHeightMap[i]);
+        writeFile->write(mHeightMap[i]);
 
     // write the material group map, after merging the flags...
     TerrainBlock::Material* materialMap = (TerrainBlock::Material*)mMaterialMap;
@@ -1207,7 +1207,7 @@ bool TerrainFile::save(const char* filename)
     {
         U8 val = mBaseMaterialMap[j];
         val |= materialMap[j].flags & TerrainBlock::Material::PersistMask;
-        writeFile.write(val);
+        writeFile->write(val);
     }
 
     // write the MaterialList Info
@@ -1225,33 +1225,36 @@ bool TerrainFile::save(const char* filename)
             if (n == TerrainBlock::BlockSize * TerrainBlock::BlockSize)
                 mMaterialFileName[k] = 0;
         }
-        writeFile.writeString(mMaterialFileName[k]);
+        writeFile->writeString(mMaterialFileName[k]);
     }
     for (k = 0; k < TerrainBlock::MaterialGroups; k++) {
         if (mMaterialFileName[k] && mMaterialFileName[k][0]) {
             AssertFatal(mMaterialAlphaMap[k] != NULL, "Error, must have a material map here!");
-            writeFile.write(TerrainBlock::BlockSize * TerrainBlock::BlockSize, mMaterialAlphaMap[k]);
+            writeFile->write(TerrainBlock::BlockSize * TerrainBlock::BlockSize, mMaterialAlphaMap[k]);
         }
     }
     if (mTextureScript)
     {
         U32 len = dStrlen(mTextureScript);
-        writeFile.write(len);
-        writeFile.write(len, mTextureScript);
+        writeFile->write(len);
+        writeFile->write(len, mTextureScript);
     }
     else
-        writeFile.write(U32(0));
+        writeFile->write(U32(0));
 
     if (mHeightfieldScript)
     {
         U32 len = dStrlen(mHeightfieldScript);
-        writeFile.write(len);
-        writeFile.write(len, mHeightfieldScript);
+        writeFile->write(len);
+        writeFile->write(len, mHeightfieldScript);
     }
     else
-        writeFile.write(U32(0));
+        writeFile->write(U32(0));
 
-    return (writeFile.getStatus() == FileStream::Ok);
+    bool result = (writeFile->getStatus() == FileStream::Ok);
+    delete writeFile;
+
+    return result;
 }
 
 //--------------------------------------

--- a/engine/source/ts/assimp/assimpShapeLoader.cpp
+++ b/engine/source/ts/assimp/assimpShapeLoader.cpp
@@ -407,12 +407,12 @@ void AssimpShapeLoader::extractTexture(U32 index, aiTexture* pTex)
    if (pTex->mHeight == 0)
    {  // Compressed format, write the data directly to disc
       texPath.setExtension(pTex->achFormatHint);
-      FileStream outputStream;
+      Stream* outputStream;
       if (ResourceManager->openFileForWrite(outputStream, texPath.getFullPath().c_str(), FileStream::Write))
       {
-         outputStream.setPosition(0);
-         outputStream.write(pTex->mWidth, pTex->pcData);
-         outputStream.close();
+         outputStream->setPosition(0);
+         outputStream->write(pTex->mWidth, pTex->pcData);
+         delete outputStream;
       }
    }
    else


### PR DESCRIPTION
This is just scaffolding for more vfs stuff happening sometime in the future. Any files saved to mem/* will be stored in memory instead of on disk and can be accessed until the game is closed.

Changeset is kinda big because I ended up refactoring openFileForWrite to return a generic Stream type instead of FileStream so most operations will seamlessly work on memory files