### PR TITLE
Fix: Discord Timer doesn't pause when a Singleplayer Scrum Game is paused

### DIFF
--- a/game/marble/server/scripts/game.cs
+++ b/game/marble/server/scripts/game.cs
@@ -320,6 +320,9 @@ function pauseGame()
             $saveTimescale = $timescale;
 
          $timescale = $pauseTimescale;
+
+         //Stop the Discord Timer since the actual in-game Timer isn't running. ~Connie
+         XBLivePresenceStopTimer();
       }
    }
 }
@@ -341,6 +344,11 @@ function resumeGame()
       if ($saveTimescale $= "")
          $saveTimescale = 1.0;
       $timescale = $saveTimescale;
+   }
+
+   //Resume the Discord Timer if it's a Singleplayer game. ~Connie
+   if ($Server::ServerType $= "SinglePlayer" && $Game::Running && serverGetGameMode() $= "scrum" && ($Game::State $= "play" || $Game::State $= "go")) {
+      XBLivePresenceStartTimer(($Game::Duration - PlayGui.elapsedTime) / 1000);
    }
 }
 


### PR DESCRIPTION
I noticed that the Discord Rich Presence Timer just kept counting down when I had a Singleplayer Scrum Game paused, and I thought it would be nice for it to... y'know, not do that anymore.

The thing now stops when the game is paused, then restarts from where it left off when unpaused - the offset of it is at most ±1 second, which isn't too bad I think.