### PR TITLE
Fix the Invite Code Option in Misc Options being broken

### DIFF
--- a/game/marble/client/ui/miscOptionsGui.gui
+++ b/game/marble/client/ui/miscOptionsGui.gui
@@ -77,7 +77,7 @@ function miscOptionsGui::show(%this, %backGui)
    // Streamer mode
    
    miscOptionsList.addRow($Text::LobbyHostStreamerMode, $Text::StreamerModeOptions, 8);
-   miscOptionsList.setOptionIndex(2, $pref::Lobby::StreamerMode);
+   miscOptionsList.setOptionIndex(3, $pref::Lobby::StreamerMode);
 
    RootGui.setA( $Text::OK );
    RootGui.setTitle( strupr($Text::HOMiscOptions) );


### PR DESCRIPTION
The issue seems to have been that the line of code which was supposed to set the option for Streamer Mode was accidentally setting the value of the Streamer Mode pref to the Invite Visibility option instead.