### PR TITLE
Use fixed vertical FOV for wide aspect ratios

### DIFF
--- a/engine/source/gui/core/guiTSControl.cpp
+++ b/engine/source/gui/core/guiTSControl.cpp
@@ -105,8 +105,19 @@ void GuiTSCtrl::onRender(Point2I offset, const RectI& updateRect)
     }
 
     // set up the camera and viewport stuff:
-    F32 wwidth = mLastCameraQuery.nearPlane * mTan(mLastCameraQuery.fov / 2);
-    F32 wheight = F32(mBounds.extent.y) / F32(mBounds.extent.x) * wwidth;
+    F32 wwidth, wheight;
+    const float referenceAspectRatio = 16.0f / 9.0f;
+
+    if (F32(mBounds.extent.x) / F32(mBounds.extent.y) > referenceAspectRatio)
+    {
+        wheight = mLastCameraQuery.nearPlane * mTan(mLastCameraQuery.fov / 2) / referenceAspectRatio;
+        wwidth = F32(mBounds.extent.x) / F32(mBounds.extent.y) * wheight;
+    }
+    else
+    {
+        wwidth = mLastCameraQuery.nearPlane * mTan(mLastCameraQuery.fov / 2);
+        wheight = F32(mBounds.extent.y) / F32(mBounds.extent.x) * wwidth;
+    }
 
     F32 hscale = wwidth * 2 / F32(mBounds.extent.x);
     F32 vscale = wheight * 2 / F32(mBounds.extent.y);


### PR DESCRIPTION
Currently, if you have an ultrawide monitor, the fixed-horizontal field of view means you're going to see the same amount horizontally, and it's only going to cut off the top and bottom. It'd be a lot better if a wider monitor fixes the vertical field of view in place and allows you to see more horizontally. This pull request makes that the case - if you are playing in an aspect ratio higher than 16/9, then the vertical FOV will be fixed and the horizontal FOV will expand, looking much more natural.

Comparison screenshots: (for whatever reason I picked 1920x720 as the aspect ratio for the ultrawide shots, which is 8:3 and not a ratio that I've heard used at all lol but it gets the point across)

| | Before | After |
| --- | --- | --- |
| 4:3 (1280x960) should look the same` | ![before-4-3-2](https://github.com/user-attachments/assets/ac3b3644-427d-4749-bf33-0c8771f47330) | ![after-4-3](https://github.com/user-attachments/assets/156732e6-e72f-48cd-9de1-b9ff4183f341) |
| 16:9 (1280x720) should look the same | ![before-16-9](https://github.com/user-attachments/assets/f44c7249-9ed5-44c6-8572-d428932166e7) | ![after-16-9](https://github.com/user-attachments/assets/cb27bc64-31fb-4edb-bbbc-e41b38aac662) |
| Ultrawide (1920x720) | ![before-ultrawide](https://github.com/user-attachments/assets/19edbddb-d4f8-4549-9839-97f972676d9f) | ![after-ultrawide](https://github.com/user-attachments/assets/2a5ff9f3-aff1-4983-9ed6-ced695d1e74c) |

These screenshots serve to demonstrate how anything below 16:9 looks exactly the same (this does _not_ sacrifice vertical FOV when playing in 4:3, for example), and for anything higher than 16:9, the vertical FOV matches 16:9 and the horizontal FOV is expanded naturally.

I make this PR for the selfish reason of: I visited my family this weekend, they have an ultrawide monitor setup and mbu looked bad on it so now is the time to fix it lol

Code mostly ported from [PQ's MBExtender hax](https://github.com/RandomityGuy/MBExtender/blob/master/MBExtender/plugins/GraphicsExtension/HorizontalFovScaling.cpp). Don't have the exact credits so: `Copyright (c) 2017, The Platinum Team`

Potential future work: clamp UI elements to remain inside a 16:9 box